### PR TITLE
Fix unsoundness in `parse_features`

### DIFF
--- a/fteepee-core/src/parsers.rs
+++ b/fteepee-core/src/parsers.rs
@@ -14,28 +14,27 @@ use crate::Result;
 pub fn parse_features(buf: &[u8]) -> std::collections::HashMap<&str, Option<&str>> {
     let lines = buf.split(|byte| *byte == b'\n');
 
-    unsafe {
-        lines
-            .filter_map(|line| match line {
-                [b' ', rest @ ..] => Some(rest),
-                _ => None,
-            })
-            .filter_map(|line| {
-                let mut group = line.splitn(2, |byte| *byte == b' ');
+    lines
+        .filter_map(|line| match line {
+            [b' ', rest @ ..] => Some(rest),
+            _ => None,
+        })
+        .filter_map(|line| {
+            let mut group = line.splitn(2, |byte| *byte == b' ');
 
-                match (group.next(), group.next()) {
-                    (Some(feature), Some(details)) => Some((
-                        std::str::from_utf8_unchecked(feature).trim(),
-                        Some(std::str::from_utf8_unchecked(details).trim()),
-                    )),
-                    (Some(feature), None) => {
-                        Some((std::str::from_utf8_unchecked(feature).trim(), None))
-                    }
-                    _ => None,
-                }
-            })
-            .collect::<std::collections::HashMap<_, _>>()
-    }
+            match (group.next(), group.next()) {
+                (Some(feature), Some(details)) => Some((
+                    std::str::from_utf8(feature).expect("Invalid UTF-8").trim(),
+                    Some(std::str::from_utf8(details).expect("Invalid UTF-8").trim()),
+                )),
+                (Some(feature), None) => Some((
+                    std::str::from_utf8(feature).expect("Invalid UTF-8").trim(),
+                    None,
+                )),
+                _ => None,
+            }
+        })
+        .collect::<std::collections::HashMap<_, _>>()
 }
 
 pub fn parse_passive_mode(buf: &[u8]) -> Result<Addr> {

--- a/fteepee-core/src/parsers.rs
+++ b/fteepee-core/src/parsers.rs
@@ -105,4 +105,10 @@ mod tests {
 
         assert_eq!(expected, feats);
     }
+
+    #[test]
+    #[should_panic(expected = "Invalid UTF-8")]
+    fn test_invalid_utf8() {
+        super::parse_features(b" \xfe \xff");
+    }
 }


### PR DESCRIPTION
I came across this crate recently and noticed it uses the `unsafe` keyword in a way that is unsound. The unsoundness can lead to remote Denial of Service (at a minimum) from malicious or poorly coded FTP servers that send invalid UTF-8 in responses. I did not audit for further security impact.

Given that this project does not contain any contributing guidelines on how to responsibly disclose security vulnerabilities, and the fact that this crate has not been published to crates.io, I believe a PR is diligent enough in this situation.

----

The PR is split into two commits. The first adds a test which proves the existence of a bug:

```
$ cargo test -p fteepee-core -- invalid
   Compiling fteepee-core v0.1.0 (./fteepee-core)
    Finished test [unoptimized + debuginfo] target(s) in 0.28s
     Running unittests src/lib.rs (./target/debug/deps/fteepee_core-8c48665956e89dd6)

running 1 test
error: test failed, to rerun pass `-p fteepee-core --lib`

Caused by:
  process didn't exit successfully: `./target/debug/deps/fteepee_core-8c48665956e89dd6 invalid` (signal: 4, SIGILL: illegal instruction)

$ lldb-15 ./target/debug/deps/fteepee_core-8c48665956e89dd6
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'lldb.embedded_interpreter'
(lldb) target create "./target/debug/deps/fteepee_core-8c48665956e89dd6"
Current executable set to './target/debug/deps/fteepee_core-8c48665956e89dd6' (x86_64).
(lldb) r
Process 5589 launched: './target/debug/deps/fteepee_core-8c48665956e89dd6' (x86_64)

running 10 tests
Process 5589 stopped
* thread #2, name = 'parsers::tests:', stop reason = signal SIGILL: illegal instruction operand
    frame #0: 0x00005555555c3585 fteepee_core-8c48665956e89dd6`core::str::validations::next_code_point::h6777317ffd521066(bytes=0x00007ffff7679ea0) at validations.rs:38:14
```

The second commit fixes the bug and removes the `unsafe` block that causes it.

It should be noted that panicking may not be an ideal solution. The function signature does not return a `Result`, so we are left with few options: Either panic or massage the data to replace the invalid characters with the replacement character, as in [`String::from_utf8_lossy()`](https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy). You may choose the lossy conversion or changing the function signature, if you prefer.

Also, note that I am not including a sample FTP server that demonstrates how this can be exploited remotely. A little analysis of the code should provide enough hints for anyone to do that if they wish. Left as an exercise to the reader, as it were.